### PR TITLE
Update README with new theme toggle info

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 This is a minimal React application.
 
+## Getting Started
+1. Run `npm install`
+2. Start the dev server with `npm run start`
+
 ## Theme Toggle
 
-Open the **Settings** section of the app to switch between light and dark mode. Enabling dark mode applies a `dark` class to the page's `<body>` element so Tailwind CSS can activate its dark color scheme. The selection is saved in `localStorage` and restored when you revisit the site.
+A dark-mode toggle is available on the main page. Enabling dark mode applies a `dark` class to the page's `<body>` element so Tailwind CSS can activate its dark color scheme. The selection is saved in `localStorage` and restored when you revisit the site.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- note that dark mode toggle is on the main page
- add a short Getting Started section

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6865f1b56378832ca1f12e6af501b935